### PR TITLE
refactor: use filename instead of file_name

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ python -m pytest --cov=src
 - **User Isolation**: Files are segregated by user ID
 - **Path Sanitization**: Prevents directory traversal attacks
 - **File Locking**: Prevents concurrent access conflicts
-- **Safe file_names**: Automatic file_name sanitization
+- **Safe filenames**: Automatic filename sanitization
 
 ## Error Handling
 

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -14,7 +14,7 @@ list_minio_files(user_id: str) -> List[Dict[str, Any]]
 
 - `user_id`: User ID for accessing user-specific files.
 - Returns: A list of dictionaries containing file information. Each dictionary has the following keys:
-  - `file_name` (str): The name of the file
+  - `filename` (str): The name of the file
   - `size` (int): The size of the file in bytes
   - `last_modified` (str, optional): The last modified timestamp in ISO format
 
@@ -23,24 +23,24 @@ list_minio_files(user_id: str) -> List[Dict[str, Any]]
 Download a file from MinIO to the local Excel directory.
 
 ```python
-pull_minio_file(user_id: str, file_name: str) -> str
+pull_minio_file(user_id: str, filename: str) -> str
 ```
 
 - `user_id`: User ID for accessing user-specific files.
-- `file_name`: Name of the file in MinIO.
-- Returns: Success message with the file_name
+- `filename`: Name of the file in MinIO.
+- Returns: Success message with the filename
 
 ### push_minio_file
 
 Upload a local Excel file to MinIO, then remove the local copy. The uploaded file gets a unique name to differentiate from originals.
 
 ```python
-push_minio_file(user_id: str, file_name: str) -> str
+push_minio_file(user_id: str, filename: str) -> str
 ```
 
 - `user_id`: User ID for accessing user-specific files.
-- `file_name`: Name of the local file to upload.
-- Returns: A dictionary containing a success message with the uploaded file_name.
+- `filename`: Name of the local file to upload.
+- Returns: A dictionary containing a success message with the uploaded filename.
 
 ## Workbook Operations
 
@@ -49,23 +49,23 @@ push_minio_file(user_id: str, file_name: str) -> str
 Create a new Excel workbook.
 
 ```python
-create_workbook(user_id: str, file_name: str) -> str
+create_workbook(user_id: str, filename: str) -> str
 ```
 
 - `user_id`: User ID for file organization
-- `file_name`: Name of the workbook file to create
-- Returns: Success message with the created file_name
+- `filename`: Name of the workbook file to create
+- Returns: Success message with the created filename
 
 ### create_worksheet
 
 Create a new worksheet in an existing workbook.
 
 ```python
-create_worksheet(user_id: str, file_name: str, sheet_name: str) -> str
+create_worksheet(user_id: str, filename: str, sheet_name: str) -> str
 ```
 
 - `user_id`: User ID for file organization
-- `file_name`: Name of the workbook file
+- `filename`: Name of the workbook file
 - `sheet_name`: Name for the new worksheet
 - Returns: Success message with the created sheet name
 
@@ -74,11 +74,11 @@ create_worksheet(user_id: str, file_name: str, sheet_name: str) -> str
 Get metadata about workbook including sheets and ranges.
 
 ```python
-get_workbook_metadata(user_id: str, file_name: str, include_ranges: bool = False) -> str
+get_workbook_metadata(user_id: str, filename: str, include_ranges: bool = False) -> str
 ```
 
 - `user_id`: User ID for file organization
-- `file_name`: Name of the workbook file
+- `filename`: Name of the workbook file
 - `include_ranges`: Whether to include range information, default to false
 - Returns: JSON string with workbook metadata
 
@@ -91,7 +91,7 @@ Write data to Excel worksheet.
 ```python
 write_data_to_excel(
     user_id: str, 
-    file_name: str,
+    filename: str,
     sheet_name: str,
     data: List[List],
     start_cell: str = "A1"
@@ -99,11 +99,11 @@ write_data_to_excel(
 ```
 
 - `user_id`: User ID for file organization
-- `file_name`: Name of the Excel file
+- `filename`: Name of the Excel file
 - `sheet_name`: Name of worksheet to write to
 - `data`: List of lists containing data to write (sublists are rows)
 - `start_cell`: Cell to start writing to, default is "A1"
-- Returns: Success message with file_name
+- Returns: Success message with filename
 
 ### read_data_from_excel
 
@@ -112,7 +112,7 @@ Read data from Excel worksheet with cell metadata including validation rules.
 ```python
 read_data_from_excel(
     user_id: str, 
-    file_name: str,
+    filename: str,
     sheet_name: str,
     start_cell: str,
     end_cell: str,
@@ -121,7 +121,7 @@ read_data_from_excel(
 ```
 
 - `user_id`: User ID for file organization
-- `file_name`: Name of the Excel file
+- `filename`: Name of the Excel file
 - `sheet_name`: Name of worksheet
 - `start_cell`: Starting cell (e.g., 'A1')
 - `end_cell`: Ending cell (e.g., 'C10')
@@ -136,7 +136,7 @@ Format a range of cells with various styling options.
 
 ```python
 format_range(
-    user_id: str, file_name: str,
+    user_id: str, filename: str,
     sheet_name: str,
     start_cell: str,
     end_cell: Optional[str] = None,
@@ -158,7 +158,7 @@ format_range(
 ```
 
 - `user_id`: User ID for file organization
-- `file_name`: Name of the Excel file
+- `filename`: Name of the Excel file
 - `sheet_name`: Name of worksheet
 - `start_cell`: Start cell of the range (e.g., 'A1')
 - `end_cell`: End cell of the range (e.g., 'C10'). Defaults to None.
@@ -176,7 +176,7 @@ format_range(
 - `merge_cells`: Whether to merge cells. Defaults to False.
 - `protection`: Cell protection settings. Defaults to None.
 - `conditional_format`: Conditional formatting rules. Defaults to None.
-- Returns: Success message with file_name
+- Returns: Success message with filename
 
 ### merge_cells
 
@@ -185,7 +185,7 @@ Merge cells in a specified range.
 ```python
 merge_cells(
     user_id: str, 
-    file_name: str,
+    filename: str,
     sheet_name: str,
     start_cell: str,
     end_cell: str
@@ -193,11 +193,11 @@ merge_cells(
 ```
 
 - `user_id`: User ID for file organization
-- `file_name`: Name of the Excel file
+- `filename`: Name of the Excel file
 - `sheet_name`: Name of worksheet
 - `start_cell`: Start cell of the range (e.g., 'A1')
 - `end_cell`: End cell of the range (e.g., 'C10')
-- Returns: Success message with file_name
+- Returns: Success message with filename
 
 ### unmerge_cells
 
@@ -206,7 +206,7 @@ Unmerge cells in a specified range.
 ```python
 unmerge_cells(
     user_id: str, 
-    file_name: str,
+    filename: str,
     sheet_name: str,
     start_cell: str,
     end_cell: str
@@ -214,22 +214,22 @@ unmerge_cells(
 ```
 
 - `user_id`: User ID for file organization
-- `file_name`: Name of the Excel file
+- `filename`: Name of the Excel file
 - `sheet_name`: Name of worksheet
 - `start_cell`: Start cell of the range (e.g., 'A1')
 - `end_cell`: End cell of the range (e.g., 'C10')
-- Returns: Success message with file_name
+- Returns: Success message with filename
 
 ### get_merged_cells
 
 Get all merged cell ranges in the worksheet.
 
 ```python
-get_merged_cells(user_id: str, file_name: str, sheet_name: str) -> str
+get_merged_cells(user_id: str, filename: str, sheet_name: str) -> str
 ```
 
 - `user_id`: User ID for file organization
-- `file_name`: Name of the Excel file
+- `filename`: Name of the Excel file
 - `sheet_name`: Name of worksheet
 - Returns: String with merged ranges information
 
@@ -241,26 +241,26 @@ get_merged_cells(user_id: str, file_name: str, sheet_name: str) -> str
 Apply Excel formula to a specific cell.
 
 ```python
-apply_formula(user_id: str, file_name: str, sheet_name: str, cell: str, formula: str) -> str
+apply_formula(user_id: str, filename: str, sheet_name: str, cell: str, formula: str) -> str
 ```
 
 - `user_id`: User ID for file organization
-- `file_name`: Name of the Excel file
+- `filename`: Name of the Excel file
 - `sheet_name`: Name of worksheet
 - `cell`: Target cell reference (e.g., 'A1')
 - `formula`: Excel formula to apply (e.g., '=SUM(A1:A10)')
-- Returns: Success message with file_name
+- Returns: Success message with filename
 
 ### validate_formula_syntax
 
 Validate Excel formula syntax without applying it to a cell.
 
 ```python
-validate_formula_syntax(user_id: str, file_name: str, sheet_name: str, cell: str, formula: str) -> str
+validate_formula_syntax(user_id: str, filename: str, sheet_name: str, cell: str, formula: str) -> str
 ```
 
 - `user_id`: User ID for file organization
-- `file_name`: Name of the Excel file
+- `filename`: Name of the Excel file
 - `sheet_name`: Name of worksheet
 - `cell`: Target cell reference (e.g., 'A1')
 - `formula`: Excel formula to validate (e.g., '=SUM(A1:A10)')
@@ -274,7 +274,7 @@ Create a chart in a worksheet with customizable options.
 
 ```python
 create_chart(
-    user_id: str, file_name: str,
+    user_id: str, filename: str,
     sheet_name: str,
     data_range: str,
     chart_type: str,
@@ -286,7 +286,7 @@ create_chart(
 ```
 
 - `user_id`: User ID for file organization
-- `file_name`: Name of the Excel file
+- `filename`: Name of the Excel file
 - `sheet_name`: Name of worksheet
 - `data_range`: Range containing chart data (e.g., 'A1:B10')
 - `chart_type`: Type of chart (line, bar, pie, scatter, area)
@@ -294,7 +294,7 @@ create_chart(
 - `title`: Optional chart title
 - `x_axis`: Optional X-axis label
 - `y_axis`: Optional Y-axis label
-- Returns: Success message with file_name
+- Returns: Success message with filename
 
 ## Pivot Table Operations
 
@@ -304,7 +304,7 @@ Create a pivot table in a worksheet with customizable options.
 
 ```python
 create_pivot_table(
-    user_id: str, file_name: str,
+    user_id: str, filename: str,
     sheet_name: str,
     data_range: str,
     rows: List[str],
@@ -315,14 +315,14 @@ create_pivot_table(
 ```
 
 - `user_id`: User ID for file organization
-- `file_name`: Name of the Excel file
+- `filename`: Name of the Excel file
 - `sheet_name`: Name of worksheet
 - `data_range`: Range containing source data (e.g., 'A1:D50')
 - `rows`: Fields for row labels (e.g., ['Region', 'Product'])
 - `values`: Fields for values (e.g., ['Sales', 'Quantity'])
 - `columns`: Optional fields for column labels (e.g., ['Year'])
 - `agg_func`: Aggregation function (sum, count, average, max, min)
-- Returns: Success message with file_name
+- Returns: Success message with filename
 
 ## Table Operations
 
@@ -332,7 +332,7 @@ Creates a native Excel table from a specified range of data with optional stylin
 
 ```python
 create_table(
-    user_id: str, file_name: str,
+    user_id: str, filename: str,
     sheet_name: str,
     data_range: str,
     table_name: Optional[str] = None,
@@ -341,12 +341,12 @@ create_table(
 ```
 
 - `user_id`: User ID for file organization
-- `file_name`: Name of the Excel file
+- `filename`: Name of the Excel file
 - `sheet_name`: Name of worksheet
 - `data_range`: The cell range for the table (e.g., "A1:D5")
 - `table_name`: Optional unique name for the table
 - `table_style`: Optional visual style for the table (e.g., "TableStyleLight1")
-- Returns: Success message with file_name
+- Returns: Success message with filename
 
 ## Worksheet Operations
 
@@ -355,41 +355,41 @@ create_table(
 Copy a worksheet within the same workbook.
 
 ```python
-copy_worksheet(user_id: str, file_name: str, source_sheet: str, target_sheet: str) -> str
+copy_worksheet(user_id: str, filename: str, source_sheet: str, target_sheet: str) -> str
 ```
 
 - `user_id`: User ID for file organization
-- `file_name`: Name of the Excel file
+- `filename`: Name of the Excel file
 - `source_sheet`: Name of sheet to copy
 - `target_sheet`: Name for new sheet
-- Returns: Success message with file_name
+- Returns: Success message with filename
 
 ### delete_worksheet
 
 Delete a worksheet from a workbook.
 
 ```python
-delete_worksheet(user_id: str, file_name: str, sheet_name: str) -> str
+delete_worksheet(user_id: str, filename: str, sheet_name: str) -> str
 ```
 
 - `user_id`: User ID for file organization
-- `file_name`: Name of the Excel file
+- `filename`: Name of the Excel file
 - `sheet_name`: Name of sheet to delete
-- Returns: Success message with file_name
+- Returns: Success message with filename
 
 ### rename_worksheet
 
 Rename a worksheet in a workbook.
 
 ```python
-rename_worksheet(user_id: str, file_name: str, old_name: str, new_name: str) -> str
+rename_worksheet(user_id: str, filename: str, old_name: str, new_name: str) -> str
 ```
 
 - `user_id`: User ID for file organization
-- `file_name`: Name of the Excel file
+- `filename`: Name of the Excel file
 - `old_name`: Current sheet name
 - `new_name`: New sheet name
-- Returns: Success message with file_name
+- Returns: Success message with filename
 
 ## Range Operations
 
@@ -399,7 +399,7 @@ Copy a range of cells to another location.
 
 ```python
 copy_range(
-    user_id: str, file_name: str,
+    user_id: str, filename: str,
     sheet_name: str,
     source_start: str,
     source_end: str,
@@ -409,13 +409,13 @@ copy_range(
 ```
 
 - `user_id`: User ID for file organization
-- `file_name`: Name of the Excel file
+- `filename`: Name of the Excel file
 - `sheet_name`: Source worksheet name
 - `source_start`: Starting cell of source range (e.g., 'A1')
 - `source_end`: Ending cell of source range (e.g., 'C10')
 - `target_start`: Starting cell for paste (e.g., 'E1')
 - `target_sheet`: Optional target worksheet name
-- Returns: Success message with file_name
+- Returns: Success message with filename
 
 ### delete_range
 
@@ -423,7 +423,7 @@ Delete a range of cells and shift remaining cells accordingly.
 
 ```python
 delete_range(
-    user_id: str, file_name: str,
+    user_id: str, filename: str,
     sheet_name: str,
     start_cell: str,
     end_cell: str,
@@ -432,12 +432,12 @@ delete_range(
 ```
 
 - `user_id`: User ID for file organization
-- `file_name`: Name of the Excel file
+- `filename`: Name of the Excel file
 - `sheet_name`: Target worksheet name
 - `start_cell`: Starting cell of range (e.g., 'A1')
 - `end_cell`: Ending cell of range (e.g., 'C10')
 - `shift_direction`: Direction to shift cells ("up", "left", or "none")
-- Returns: Success message with file_name
+- Returns: Success message with filename
 
 ### validate_excel_range
 
@@ -445,7 +445,7 @@ Validate if a range exists and is properly formatted in a worksheet.
 
 ```python
 validate_excel_range(
-    user_id: str, file_name: str,
+    user_id: str, filename: str,
     sheet_name: str,
     start_cell: str,
     end_cell: str
@@ -453,11 +453,11 @@ validate_excel_range(
 ```
 
 - `user_id`: User ID for file organization
-- `file_name`: Name of the Excel file
+- `filename`: Name of the Excel file
 - `sheet_name`: Target worksheet name
 - `start_cell`: Starting cell of range (e.g., 'A1')
 - `end_cell`: Ending cell of range (e.g., 'C3')
-- Returns: Success message with file_name
+- Returns: Success message with filename
 
 ### get_data_validation_info
 
@@ -467,11 +467,11 @@ This tool helps identify which cell ranges have validation rules
 and what types of validation are applied.
 
 ```python
-get_data_validation_info(user_id: str, file_name: str, sheet_name: str) -> str
+get_data_validation_info(user_id: str, filename: str, sheet_name: str) -> str
 ```
 
 - `user_id`: User ID for file organization
-- `file_name`: Name of the Excel file
+- `filename`: Name of the Excel file
 - `sheet_name`: Name of worksheet
 - Returns: JSON string containing all validation rules in the worksheet
 
@@ -483,7 +483,7 @@ Insert one or more rows starting at the specified row.
 
 ```python
 insert_rows(
-    user_id: str, file_name: str,
+    user_id: str, filename: str,
     sheet_name: str,
     start_row: int,
     count: int = 1
@@ -491,11 +491,11 @@ insert_rows(
 ```
 
 - `user_id`: User ID for file organization
-- `file_name`: Name of the Excel file
+- `filename`: Name of the Excel file
 - `sheet_name`: Target worksheet name
 - `start_row`: Row number where to start inserting (1-based)
 - `count`: Number of rows to insert (default: 1)
-- Returns: Success message with file_name
+- Returns: Success message with filename
 
 ### insert_columns
 
@@ -503,7 +503,7 @@ Insert one or more columns starting at the specified column.
 
 ```python
 insert_columns(
-    user_id: str, file_name: str,
+    user_id: str, filename: str,
     sheet_name: str,
     start_col: int,
     count: int = 1
@@ -511,11 +511,11 @@ insert_columns(
 ```
 
 - `user_id`: User ID for file organization
-- `file_name`: Name of the Excel file
+- `filename`: Name of the Excel file
 - `sheet_name`: Target worksheet name
 - `start_col`: Column number where to start inserting (1-based)
 - `count`: Number of columns to insert (default: 1)
-- Returns: Success message with file_name
+- Returns: Success message with filename
 
 ### delete_sheet_rows
 
@@ -523,7 +523,7 @@ Delete one or more rows starting at the specified row.
 
 ```python
 delete_sheet_rows(
-    user_id: str, file_name: str,
+    user_id: str, filename: str,
     sheet_name: str,
     start_row: int,
     count: int = 1
@@ -531,11 +531,11 @@ delete_sheet_rows(
 ```
 
 - `user_id`: User ID for file organization
-- `file_name`: Name of the Excel file
+- `filename`: Name of the Excel file
 - `sheet_name`: Target worksheet name
 - `start_row`: Row number where to start deleting (1-based)
 - `count`: Number of rows to delete (default: 1)
-- Returns: Success message with file_name
+- Returns: Success message with filename
 
 ### delete_sheet_columns
 
@@ -543,7 +543,7 @@ Delete one or more columns starting at the specified column.
 
 ```python
 delete_sheet_columns(
-    user_id: str, file_name: str,
+    user_id: str, filename: str,
     sheet_name: str,
     start_col: int,
     count: int = 1
@@ -551,11 +551,11 @@ delete_sheet_columns(
 ```
 
 - `user_id`: User ID for file organization
-- `file_name`: Name of the Excel file
+- `filename`: Name of the Excel file
 - `sheet_name`: Target worksheet name
 - `start_col`: Column number where to start deleting (1-based)
 - `count`: Number of columns to delete (default: 1)
-- Returns: Success message with file_name
+- Returns: Success message with filename
 
 ## Tool Categories
 
@@ -573,6 +573,6 @@ The tools are organized into the following categories based on their functionali
 - **Range Operations**: Working with cell ranges
 - **Row and Column Operations**: Inserting and deleting rows/columns
 
-Each tool includes proper error handling and returns user-friendly messages with the file_name (not full paths) for security and usability.
+Each tool includes proper error handling and returns user-friendly messages with the filename (not full paths) for security and usability.
 
 **Note**: The `read_data_from_excel` tool automatically includes validation metadata for individual cells when available.

--- a/src/core/file_manager.py
+++ b/src/core/file_manager.py
@@ -37,20 +37,20 @@ class FileManager:
         user_dir.mkdir(parents=True, exist_ok=True)
         return user_dir
     
-    def get_file_path(self, file_name: str, user_id: str) -> Path:
+    def get_file_path(self, filename: str, user_id: str) -> Path:
         """
         Get the full path for a user's file.
         
         Args:
-            file_name: Name of the file (without path)
+            filename: Name of the file (without path)
             user_id: User identifier
             
         Returns:
             Full path to the file
         """
-        # Extract just the file_name from any path input to avoid confusion
-        file_name = Path(file_name).name
-        return self.get_user_directory(user_id) / file_name
+        # Extract just the filename from any path input to avoid confusion
+        filename = Path(filename).name
+        return self.get_user_directory(user_id) / filename
     
     @contextmanager
     def lock_file(self, file_path: Union[str, Path], timeout: float = 30.0):
@@ -77,14 +77,14 @@ class FileManager:
                 lock.release()
 
 
-def get_safe_file_name(file_name: str) -> str:
+def get_safe_filename(filename: str) -> str:
     """
-    Extract safe file_name from path and ensure it's just a file_name.
+    Extract safe filename from path and ensure it's just a filename.
     
     Args:
-        file_name: Input file_name or path
+        filename: Input filename or path
         
     Returns:
-        Safe file_name without path components
+        Safe filename without path components
     """
-    return Path(file_name).name
+    return Path(filename).name

--- a/src/tools/excel_read.py
+++ b/src/tools/excel_read.py
@@ -2,7 +2,7 @@ import logging
 import json
 from typing import Optional
 from openpyxl import load_workbook
-from ..core.file_manager import get_safe_file_name
+from ..core.file_manager import get_safe_filename
 from ..utils.data import read_excel_range_with_metadata
 from ..utils.validation import validate_formula_in_cell_operation as validate_formula_impl
 from ..utils.validation import validate_range_in_sheet_operation as validate_range_impl
@@ -21,7 +21,7 @@ def register_excel_read_tools(mcp_server):
     @mcp_server.tool(tags={"excel", "read"})
     def read_data_from_excel(
         user_id: str,
-        file_name: str,
+        filename: str,
         sheet_name: str,
         start_cell: str,
         end_cell: str,
@@ -32,7 +32,7 @@ def register_excel_read_tools(mcp_server):
         
         Args:
             user_id: User ID for file organization
-            file_name: Name of the Excel file
+            filename: Name of the Excel file
             sheet_name: Name of worksheet
             start_cell: Starting cell
             end_cell: Ending cell
@@ -42,8 +42,8 @@ def register_excel_read_tools(mcp_server):
             JSON string containing structured cell data with validation metadata.
             Each cell includes: address, value, row, column, and validation info (if any).
         """
-        safe_file_name = get_safe_file_name(file_name)
-        file_path = mcp_server.file_manager.get_file_path(safe_file_name, user_id)
+        safe_filename = get_safe_filename(filename)
+        file_path = mcp_server.file_manager.get_file_path(safe_filename, user_id)
         try:
             with mcp_server.file_manager.lock_file(file_path):
                 result = read_excel_range_with_metadata(
@@ -62,7 +62,7 @@ def register_excel_read_tools(mcp_server):
     @mcp_server.tool(tags={"excel", "read"})
     def validate_formula_syntax(
         user_id: str,
-        file_name: str,
+        filename: str,
         sheet_name: str,
         cell: str,
         formula: str,
@@ -72,7 +72,7 @@ def register_excel_read_tools(mcp_server):
         
         Args:
             user_id: User ID for file organization
-            file_name: Name of the Excel file
+            filename: Name of the Excel file
             sheet_name: Name of worksheet
             cell: Target cell address (e.g., 'A1')
             formula: Excel formula to validate
@@ -80,15 +80,15 @@ def register_excel_read_tools(mcp_server):
         Returns:
             Validation result message indicating if the formula is valid or not
         """
-        safe_file_name = get_safe_file_name(file_name)
-        file_path = mcp_server.file_manager.get_file_path(safe_file_name, user_id)
+        safe_filename = get_safe_filename(filename)
+        file_path = mcp_server.file_manager.get_file_path(safe_filename, user_id)
         try:
             with mcp_server.file_manager.lock_file(file_path):
                 result = validate_formula_impl(str(file_path), sheet_name, cell, formula)
-                safe_result = result["message"].replace(str(file_path), safe_file_name)
+                safe_result = result["message"].replace(str(file_path), safe_filename)
                 return safe_result
         except (ValidationError, CalculationError) as e:
-            safe_error = str(e).replace(str(file_path), safe_file_name)
+            safe_error = str(e).replace(str(file_path), safe_filename)
             return f"Error: {safe_error}"
         except Exception as e:
             logger.error(f"Error validating formula: {e}")
@@ -98,7 +98,7 @@ def register_excel_read_tools(mcp_server):
     @mcp_server.tool(tags={"excel", "read"})
     def validate_excel_range(
         user_id: str,
-        file_name: str,
+        filename: str,
         sheet_name: str,
         start_cell: str,
         end_cell: str
@@ -108,24 +108,24 @@ def register_excel_read_tools(mcp_server):
         
         Args:
             user_id (str): User ID for file organization
-            file_name (str): Name of the Excel file
+            filename (str): Name of the Excel file
             sheet_name (str): Name of worksheet
             start_cell (str): Starting cell of range to validate (e.g., "A1")
             end_cell (str): Ending cell of range to validate (e.g., "C3").
                 If not provided, only the start_cell is validated. Defaults to None.
                 
         Returns:
-            str: Success message with file_name
+            str: Success message with filename
         """
-        safe_file_name = get_safe_file_name(file_name)
-        file_path = mcp_server.file_manager.get_file_path(safe_file_name, user_id)
+        safe_filename = get_safe_filename(filename)
+        file_path = mcp_server.file_manager.get_file_path(safe_filename, user_id)
         try:
             with mcp_server.file_manager.lock_file(file_path):
                 result = validate_range_impl(str(file_path), sheet_name, start_cell, end_cell)
-                safe_result = result["message"].replace(str(file_path), f"'{safe_file_name}'")
+                safe_result = result["message"].replace(str(file_path), f"'{safe_filename}'")
                 return safe_result
         except (ValidationError) as e:
-            safe_error = str(e).replace(str(file_path), f"'{safe_file_name}'")
+            safe_error = str(e).replace(str(file_path), f"'{safe_filename}'")
             return f"Error: {safe_error}"
         except Exception as e:
             logger.error(f"Error validating range: {e}")
@@ -134,7 +134,7 @@ def register_excel_read_tools(mcp_server):
     @mcp_server.tool(tags={"excel", "read"})
     def get_data_validation_info(
         user_id: str,
-        file_name: str,
+        filename: str,
         sheet_name: str
     ) -> str:
         """
@@ -145,14 +145,14 @@ def register_excel_read_tools(mcp_server):
         
         Args:
             user_id (str): User ID for file organization
-            file_name (str): Name of the Excel file
+            filename (str): Name of the Excel file
             sheet_name (str): Name of worksheet
             
         Returns:
             str: JSON string containing all validation rules in the worksheet
         """
-        safe_file_name = get_safe_file_name(file_name)
-        file_path = mcp_server.file_manager.get_file_path(safe_file_name, user_id)
+        safe_filename = get_safe_filename(filename)
+        file_path = mcp_server.file_manager.get_file_path(safe_filename, user_id)
         try:
             with mcp_server.file_manager.lock_file(file_path):
                 wb = load_workbook(str(file_path), read_only=False)
@@ -164,7 +164,7 @@ def register_excel_read_tools(mcp_server):
                 if not validations:
                     return "No data validation rules found in this worksheet"
                 return json.dumps({
-                    "file_name": safe_file_name,
+                    "filename": safe_filename,
                     "sheet_name": sheet_name,
                     "validation_rules": validations
                 }, indent=2, default=str)
@@ -175,27 +175,27 @@ def register_excel_read_tools(mcp_server):
         
     # Sheet related tools
     @mcp_server.tool(tags={"excel", "read"})
-    def get_merged_cells(user_id: str, file_name: str, sheet_name: str) -> str:
+    def get_merged_cells(user_id: str, filename: str, sheet_name: str) -> str:
         """
         Get all merged cell ranges in the worksheet.
         
         Args:
             user_id: User ID for file organization
-            file_name: Name of the Excel file
+            filename: Name of the Excel file
             sheet_name: Name of worksheet
             
         Returns:
             String with merged ranges information
         """
-        safe_file_name = get_safe_file_name(file_name)
-        file_path = mcp_server.file_manager.get_file_path(safe_file_name, user_id)
+        safe_filename = get_safe_filename(filename)
+        file_path = mcp_server.file_manager.get_file_path(safe_filename, user_id)
         try:
             with mcp_server.file_manager.lock_file(file_path):
                 result = str(get_merged_ranges(str(file_path), sheet_name))
-                safe_result = result.replace(str(file_path), f"'{safe_file_name}'")
+                safe_result = result.replace(str(file_path), f"'{safe_filename}'")
                 return safe_result
         except (ValidationError, SheetError) as e:
-            safe_error = str(e).replace(str(file_path), f"'{safe_file_name}'")
+            safe_error = str(e).replace(str(file_path), f"'{safe_filename}'")
             return f"Error: {safe_error}"
         except Exception as e:
             logger.error(f"Error getting merged cells: {e}")
@@ -205,7 +205,7 @@ def register_excel_read_tools(mcp_server):
     @mcp_server.tool(tags={"excel", "read"})
     def get_workbook_metadata(
         user_id: str, 
-        file_name: str, 
+        filename: str, 
         include_ranges: bool = False
     ) -> str:
         """
@@ -213,23 +213,23 @@ def register_excel_read_tools(mcp_server):
         
         Args:
             user_id: User ID for file organization
-            file_name: Name of the workbook file
+            filename: Name of the workbook file
             include_ranges: Whether to include range information, default to false
             
         Returns:
             JSON string with workbook metadata
         """
-        safe_file_name = get_safe_file_name(file_name)
-        file_path = mcp_server.file_manager.get_file_path(safe_file_name, user_id)
+        safe_filename = get_safe_filename(filename)
+        file_path = mcp_server.file_manager.get_file_path(safe_filename, user_id)
         try:
             with mcp_server.file_manager.lock_file(file_path):
                 result = get_workbook_info(str(file_path), include_ranges=include_ranges)
-                # Normalize file_name to avoid leaking any path and align with other tools' outputs
+                # Normalize filename to avoid leaking any path and align with other tools' outputs
                 if isinstance(result, dict):
-                    result["file_name"] = safe_file_name
+                    result["filename"] = safe_filename
                 return json.dumps(result, indent=2, default=str)
         except WorkbookError as e:
-            safe_error = str(e).replace(str(file_path), f"'{safe_file_name}'")
+            safe_error = str(e).replace(str(file_path), f"'{safe_filename}'")
             return f"Error: {safe_error}"
         except Exception as e:
             logger.error(f"Error getting workbook metadata: {e}")

--- a/src/tools/excel_write.py
+++ b/src/tools/excel_write.py
@@ -1,6 +1,6 @@
 import logging
 from typing import Optional, List, Dict, Any
-from ..core.file_manager import get_safe_file_name
+from ..core.file_manager import get_safe_filename
 from ..utils.chart import create_chart_in_sheet as create_chart_impl
 from ..utils.pivot import create_pivot_table as create_pivot_table_impl
 from ..utils.tables import create_excel_table as create_table_impl
@@ -41,7 +41,7 @@ def register_excel_write_tools(mcp_server):
     @mcp_server.tool(tags={"excel", "write"})
     def create_chart(
         user_id: str,
-        file_name: str,
+        filename: str,
         sheet_name: str,
         data_range: str,
         chart_type: str,
@@ -55,7 +55,7 @@ def register_excel_write_tools(mcp_server):
         
         Args:
             user_id (str): User ID for file organization
-            file_name (str): Name of the Excel file
+            filename (str): Name of the Excel file
             sheet_name (str): Name of worksheet
             data_range (str): Range of data to chart (e.g., 'A1:C10')
             chart_type (str): Type of chart (e.g., 'line', 'bar', 'column', 'pie')
@@ -65,10 +65,10 @@ def register_excel_write_tools(mcp_server):
             y_axis (str, optional): Y-axis title. Defaults to "".
             
         Returns:
-            str: Success message with file_name
+            str: Success message with filename
         """
-        safe_file_name = get_safe_file_name(file_name)
-        file_path = mcp_server.file_manager.get_file_path(safe_file_name, user_id)
+        safe_filename = get_safe_filename(filename)
+        file_path = mcp_server.file_manager.get_file_path(safe_filename, user_id)
         try:
             with mcp_server.file_manager.lock_file(file_path):
                 result = create_chart_impl(
@@ -81,10 +81,10 @@ def register_excel_write_tools(mcp_server):
                     x_axis=x_axis,
                     y_axis=y_axis
                 )
-                safe_result = result["message"].replace(str(file_path), safe_file_name)
+                safe_result = result["message"].replace(str(file_path), safe_filename)
                 return safe_result
         except (ValidationError, ChartError) as e:
-            safe_error = str(e).replace(str(file_path), safe_file_name)
+            safe_error = str(e).replace(str(file_path), safe_filename)
             return f"Error: {safe_error}"
         except Exception as e:
             logger.error(f"Error creating chart: {e}")
@@ -93,7 +93,7 @@ def register_excel_write_tools(mcp_server):
     @mcp_server.tool(tags={"excel", "write"})
     def create_pivot_table(
         user_id: str,
-        file_name: str,
+        filename: str,
         sheet_name: str,
         data_range: str,
         rows: List[str],
@@ -106,7 +106,7 @@ def register_excel_write_tools(mcp_server):
         
         Args:
             user_id (str): User ID for file organization
-            file_name (str): Name of the Excel file
+            filename (str): Name of the Excel file
             sheet_name (str): Source worksheet name
             data_range (str): Data range for pivot table (e.g., 'A1:D100')
             rows (List[str]): List of field names for row area
@@ -115,10 +115,10 @@ def register_excel_write_tools(mcp_server):
             agg_func (str, optional): Aggregation function (sum, count, average, max, min). Defaults to "sum".
             
         Returns:
-            str: Success message with file_name
+            str: Success message with filename
         """
-        safe_file_name = get_safe_file_name(file_name)
-        file_path = mcp_server.file_manager.get_file_path(safe_file_name, user_id)
+        safe_filename = get_safe_filename(filename)
+        file_path = mcp_server.file_manager.get_file_path(safe_filename, user_id)
         try:
             with mcp_server.file_manager.lock_file(file_path):
                 result = create_pivot_table_impl(
@@ -130,10 +130,10 @@ def register_excel_write_tools(mcp_server):
                     columns=columns or [],
                     agg_func=agg_func
                 )
-                safe_result = result["message"].replace(str(file_path), safe_file_name)
+                safe_result = result["message"].replace(str(file_path), safe_filename)
                 return safe_result
         except (PivotError, ValidationError) as e:
-            safe_error = str(e).replace(str(file_path), safe_file_name)
+            safe_error = str(e).replace(str(file_path), safe_filename)
             return f"Pivot Error: {safe_error}"
         except Exception as e:
             logger.error(f"Error creating pivot table: {e}")
@@ -142,7 +142,7 @@ def register_excel_write_tools(mcp_server):
     @mcp_server.tool(tags={"excel", "write"})
     def create_table(
         user_id: str,
-        file_name: str,
+        filename: str,
         sheet_name: str,
         data_range: str,
         table_name: Optional[str] = None,
@@ -153,17 +153,17 @@ def register_excel_write_tools(mcp_server):
         
         Args:
             user_id (str): User ID for file organization
-            file_name (str): Name of the Excel file
+            filename (str): Name of the Excel file
             sheet_name (str): Name of worksheet
             data_range (str): Range to convert to table (e.g., 'A1:D10')
             table_name (Optional[str], optional): Name for the table. Defaults to None.
             table_style (str, optional): Table's style. Defaults to "TableStyleMedium9".
             
         Returns:
-            str: Success message with file_name
+            str: Success message with filename
         """
-        safe_file_name = get_safe_file_name(file_name)
-        file_path = mcp_server.file_manager.get_file_path(safe_file_name, user_id)
+        safe_filename = get_safe_filename(filename)
+        file_path = mcp_server.file_manager.get_file_path(safe_filename, user_id)
         try:
             with mcp_server.file_manager.lock_file(file_path):
                 result = create_table_impl(
@@ -173,10 +173,10 @@ def register_excel_write_tools(mcp_server):
                     table_name=table_name,
                     table_style=table_style
                 )
-                safe_result = result["message"].replace(str(file_path), safe_file_name)
+                safe_result = result["message"].replace(str(file_path), safe_filename)
                 return safe_result
         except DataError as e:
-            safe_error = str(e).replace(str(file_path), safe_file_name)
+            safe_error = str(e).replace(str(file_path), safe_filename)
             return f"Data Error: {safe_error}"
         except Exception as e:
             logger.error(f"Error creating table: {e}")
@@ -186,7 +186,7 @@ def register_excel_write_tools(mcp_server):
     @mcp_server.tool(tags={"excel", "write"})
     def write_data_to_excel(
         user_id: str,
-        file_name: str,
+        filename: str,
         sheet_name: str,
         data: List[List],
         start_cell: str = "A1",
@@ -196,23 +196,23 @@ def register_excel_write_tools(mcp_server):
         
         Args:
             user_id: User ID for file organization
-            file_name: Name of the Excel file
+            filename: Name of the Excel file
             sheet_name: Name of worksheet to write to
             data: List of lists containing data to write (sublists are rows)
             start_cell: Cell to start writing to, default is "A1"
         
         Returns:
-            Success message with file_name
+            Success message with filename
         """
-        safe_file_name = get_safe_file_name(file_name)
-        file_path = mcp_server.file_manager.get_file_path(safe_file_name, user_id)
+        safe_filename = get_safe_filename(filename)
+        file_path = mcp_server.file_manager.get_file_path(safe_filename, user_id)
         try:
             with mcp_server.file_manager.lock_file(file_path):
                 result = write_data(str(file_path), sheet_name, data, start_cell)
-                safe_result = result["message"].replace(str(file_path), safe_file_name)
+                safe_result = result["message"].replace(str(file_path), safe_filename)
                 return safe_result
         except (ValidationError, DataError) as e:
-            safe_error = str(e).replace(str(file_path), safe_file_name)
+            safe_error = str(e).replace(str(file_path), safe_filename)
             return f"Error: {safe_error}"
         except Exception as e:
             logger.error(f"Error writing data: {e}")
@@ -221,7 +221,7 @@ def register_excel_write_tools(mcp_server):
     @mcp_server.tool(tags={"excel", "write"})
     def apply_formula(
         user_id: str,
-        file_name: str,
+        filename: str,
         sheet_name: str,
         cell: str,
         formula: str,
@@ -231,28 +231,28 @@ def register_excel_write_tools(mcp_server):
         
         Args:
             user_id: User ID for file organization
-            file_name: Name of the Excel file
+            filename: Name of the Excel file
             sheet_name: Name of worksheet
             cell: Target cell address (e.g., 'A1')
             formula: Excel formula to apply
             
         Returns:
-            Success message with file_name
+            Success message with filename
         """
-        safe_file_name = get_safe_file_name(file_name)
-        file_path = mcp_server.file_manager.get_file_path(safe_file_name, user_id)
+        safe_filename = get_safe_filename(filename)
+        file_path = mcp_server.file_manager.get_file_path(safe_filename, user_id)
         try:
             with mcp_server.file_manager.lock_file(file_path):
                 validation = validate_formula_impl(str(file_path), sheet_name, cell, formula)
                 if isinstance(validation, dict) and "error" in validation:
-                    safe_error = validation["error"].replace(str(file_path), safe_file_name)
+                    safe_error = validation["error"].replace(str(file_path), safe_filename)
                     return f"Error: {safe_error}"
                 # then apply the formula
                 result = apply_formula_impl(str(file_path), sheet_name, cell, formula)
-                safe_result = result["message"].replace(str(file_path), safe_file_name)
+                safe_result = result["message"].replace(str(file_path), safe_filename)
                 return safe_result
         except (ValidationError, CalculationError) as e:
-            safe_error = str(e).replace(str(file_path), safe_file_name)
+            safe_error = str(e).replace(str(file_path), safe_filename)
             return f"Error: {safe_error}"
         except Exception as e:
             logger.error(f"Error applying formula: {e}")
@@ -263,7 +263,7 @@ def register_excel_write_tools(mcp_server):
     @mcp_server.tool(tags={"excel", "write"})
     def format_range(
         user_id: str,
-        file_name: str,
+        filename: str,
         sheet_name: str,
         start_cell: str,
         end_cell: Optional[str] = None,
@@ -287,7 +287,7 @@ def register_excel_write_tools(mcp_server):
         
         Args:
             user_id (str): User ID for file organization
-            file_name (str): Name of the Excel file
+            filename (str): Name of the Excel file
             sheet_name (str): Name of worksheet
             start_cell (str): Start cell of the range (e.g., 'A1')
             end_cell (Optional[str], optional): End cell of the range (e.g., 'C10'). Defaults to None.
@@ -307,10 +307,10 @@ def register_excel_write_tools(mcp_server):
             conditional_format (Optional[Dict[str, Any]], optional): Conditional formatting rules. Defaults to None.
             
         Returns:
-            str: Success message with file_name
+            str: Success message with filename
         """
-        safe_file_name = get_safe_file_name(file_name)
-        file_path = mcp_server.file_manager.get_file_path(safe_file_name, user_id)
+        safe_filename = get_safe_filename(filename)
+        file_path = mcp_server.file_manager.get_file_path(safe_filename, user_id)
         try:
             with mcp_server.file_manager.lock_file(file_path):
                 result = format_range_func(
@@ -333,10 +333,10 @@ def register_excel_write_tools(mcp_server):
                     protection=protection,  # This can be None
                     conditional_format=conditional_format  # This can be None
                 )
-                safe_result = result["message"].replace(str(file_path), f"'{safe_file_name}'")
+                safe_result = result["message"].replace(str(file_path), f"'{safe_filename}'")
                 return safe_result
         except (ValidationError, FormattingError) as e:
-            safe_error = str(e).replace(str(file_path), f"'{safe_file_name}'")
+            safe_error = str(e).replace(str(file_path), f"'{safe_filename}'")
             return f"Error: {safe_error}"
         except Exception as e:
             logger.error(f"Error formatting range: {e}")
@@ -345,7 +345,7 @@ def register_excel_write_tools(mcp_server):
     @mcp_server.tool(tags={"excel", "write"})
     def copy_range(
         user_id: str,
-        file_name: str,
+        filename: str,
         sheet_name: str,
         source_start: str,
         source_end: str,
@@ -357,7 +357,7 @@ def register_excel_write_tools(mcp_server):
         
         Args:
             user_id (str): User ID for file organization
-            file_name (str): Name of the Excel file
+            filename (str): Name of the Excel file
             sheet_name (str): Name of worksheet
             source_start (str): Starting cell of source range (e.g., "A1")
             source_end (str): Ending cell of source range (e.g., "C3")
@@ -366,10 +366,10 @@ def register_excel_write_tools(mcp_server):
                 If not provided, uses the source sheet. Defaults to None.
                 
         Returns:
-            str: Success message with file_name
+            str: Success message with filename
         """
-        safe_file_name = get_safe_file_name(file_name)
-        file_path = mcp_server.file_manager.get_file_path(safe_file_name, user_id)
+        safe_filename = get_safe_filename(filename)
+        file_path = mcp_server.file_manager.get_file_path(safe_filename, user_id)
         try:
             with mcp_server.file_manager.lock_file(file_path):
                 result = copy_range_operation(
@@ -380,10 +380,10 @@ def register_excel_write_tools(mcp_server):
                     target_start = target_start,
                     target_sheet = target_sheet or sheet_name  # Use source sheet if target_sheet is None
                 )
-                safe_result = result["message"].replace(str(file_path), f"'{safe_file_name}'")
+                safe_result = result["message"].replace(str(file_path), f"'{safe_filename}'")
                 return safe_result
         except (ValidationError, SheetError) as e:
-            safe_error = str(e).replace(str(file_path), f"'{safe_file_name}'")
+            safe_error = str(e).replace(str(file_path), f"'{safe_filename}'")
             return f"Error: {safe_error}"
         except Exception as e:
             logger.error(f"Error copying range: {e}")
@@ -392,7 +392,7 @@ def register_excel_write_tools(mcp_server):
     @mcp_server.tool(tags={"excel", "write"})
     def delete_range(
         user_id: str,
-        file_name: str,
+        filename: str,
         sheet_name: str,
         start_cell: str,
         end_cell: str,
@@ -403,7 +403,7 @@ def register_excel_write_tools(mcp_server):
         
         Args:
             user_id (str): User ID for file organization
-            file_name (str): Name of the Excel file
+            filename (str): Name of the Excel file
             sheet_name (str): Name of worksheet
             start_cell (str): Starting cell of range to delete (e.g., "A1")
             end_cell (str): Ending cell of range to delete (e.g., "C3")
@@ -411,10 +411,10 @@ def register_excel_write_tools(mcp_server):
                 Valid values are "up", "left", "none". Defaults to "up".
                 
         Returns:
-            str: Success message with file_name
+            str: Success message with filename
         """
-        safe_file_name = get_safe_file_name(file_name)
-        file_path = mcp_server.file_manager.get_file_path(safe_file_name, user_id)
+        safe_filename = get_safe_filename(filename)
+        file_path = mcp_server.file_manager.get_file_path(safe_filename, user_id)
         try:
             with mcp_server.file_manager.lock_file(file_path):
                 result = delete_range_operation(
@@ -424,10 +424,10 @@ def register_excel_write_tools(mcp_server):
                     end_cell=end_cell,
                     shift_direction=shift_direction
                 )
-                safe_result = result["message"].replace(str(file_path), f"'{safe_file_name}'")
+                safe_result = result["message"].replace(str(file_path), f"'{safe_filename}'")
                 return safe_result
         except (ValidationError, SheetError) as e:
-            safe_error = str(e).replace(str(file_path), f"'{safe_file_name}'")
+            safe_error = str(e).replace(str(file_path), f"'{safe_filename}'")
             return f"Error: {safe_error}"
         except Exception as e:
             logger.error(f"Error deleting range: {e}")
@@ -435,152 +435,152 @@ def register_excel_write_tools(mcp_server):
         
     # Sheet related tools
     @mcp_server.tool(tags={"excel", "write"})
-    def copy_worksheet(user_id: str, file_name: str, source_sheet: str, target_sheet: str) -> str:
+    def copy_worksheet(user_id: str, filename: str, source_sheet: str, target_sheet: str) -> str:
         """
         Copy a worksheet within the same workbook.
         
         Args:
             user_id (str): User ID for file organization. This parameter is required.
-            file_name (str): Name of the Excel file. This parameter is required.
+            filename (str): Name of the Excel file. This parameter is required.
             source_sheet (str): Name of source worksheet to copy. This parameter is required.
             target_sheet (str): Name for the new copied worksheet. This parameter is required.
             
         Returns:
-            str: Success message with file_name.
+            str: Success message with filename.
         """
-        safe_file_name = get_safe_file_name(file_name)
-        file_path = mcp_server.file_manager.get_file_path(safe_file_name, user_id)
+        safe_filename = get_safe_filename(filename)
+        file_path = mcp_server.file_manager.get_file_path(safe_filename, user_id)
         try:
             with mcp_server.file_manager.lock_file(file_path):
                 result = copy_sheet(str(file_path), source_sheet, target_sheet)
-                safe_result = result["message"].replace(str(file_path), f"'{safe_file_name}'")
+                safe_result = result["message"].replace(str(file_path), f"'{safe_filename}'")
                 return safe_result
         except (ValidationError, SheetError) as e:
-            safe_error = str(e).replace(str(file_path), f"'{safe_file_name}'")
+            safe_error = str(e).replace(str(file_path), f"'{safe_filename}'")
             return f"Error: {safe_error}"
         except Exception as e:
             logger.error(f"Error copying worksheet: {e}")
             raise
         
     @mcp_server.tool(tags={"excel", "write"})
-    def delete_worksheet(user_id: str, file_name: str, sheet_name: str) -> str:
+    def delete_worksheet(user_id: str, filename: str, sheet_name: str) -> str:
         """
         Delete a worksheet from the workbook.
         
         Args:
             user_id: User ID for file organization
-            file_name: Name of the Excel file
+            filename: Name of the Excel file
             sheet_name: Name of worksheet to delete
             
         Returns:
-            str: Success message with file_name
+            str: Success message with filename
         """
-        safe_file_name = get_safe_file_name(file_name)
-        file_path = mcp_server.file_manager.get_file_path(safe_file_name, user_id)
+        safe_filename = get_safe_filename(filename)
+        file_path = mcp_server.file_manager.get_file_path(safe_filename, user_id)
         try:
             with mcp_server.file_manager.lock_file(file_path):
                 result = delete_sheet(str(file_path), sheet_name)
-                safe_result = result["message"].replace(str(file_path), f"'{safe_file_name}'")
+                safe_result = result["message"].replace(str(file_path), f"'{safe_filename}'")
                 return safe_result
         except (ValidationError, SheetError) as e:
-            safe_error = str(e).replace(str(file_path), f"'{safe_file_name}'")
+            safe_error = str(e).replace(str(file_path), f"'{safe_filename}'")
             return f"Error: {safe_error}"
         except Exception as e:
             logger.error(f"Error deleting worksheet: {e}")
             raise
 
     @mcp_server.tool(tags={"excel", "write"})
-    def rename_worksheet(user_id: str, file_name: str, old_name: str, new_name: str) -> str:
+    def rename_worksheet(user_id: str, filename: str, old_name: str, new_name: str) -> str:
         """
         Rename a worksheet in the workbook.
         
         Args:
             user_id: User ID for file organization
-            file_name: Name of the Excel file
+            filename: Name of the Excel file
             old_name: Current name of worksheet
             new_name: New name for worksheet
             
         Returns:
-            Success message with file_name
+            Success message with filename
         """
-        safe_file_name = get_safe_file_name(file_name)
-        file_path = mcp_server.file_manager.get_file_path(safe_file_name, user_id)
+        safe_filename = get_safe_filename(filename)
+        file_path = mcp_server.file_manager.get_file_path(safe_filename, user_id)
         try:
             with mcp_server.file_manager.lock_file(file_path):
                 result = rename_sheet(str(file_path), old_name, new_name)
-                safe_result = result["message"].replace(str(file_path), f"'{safe_file_name}'")
+                safe_result = result["message"].replace(str(file_path), f"'{safe_filename}'")
                 return safe_result
         except (ValidationError, SheetError) as e:
-            safe_error = str(e).replace(str(file_path), f"'{safe_file_name}'")
+            safe_error = str(e).replace(str(file_path), f"'{safe_filename}'")
             return f"Error: {safe_error}"
         except Exception as e:
             logger.error(f"Error renaming worksheet: {e}")
             raise
         
     @mcp_server.tool(tags={"excel", "write"})
-    def merge_cells(user_id: str, file_name: str, sheet_name: str, start_cell: str, end_cell: str) -> str:
+    def merge_cells(user_id: str, filename: str, sheet_name: str, start_cell: str, end_cell: str) -> str:
         """
         Merge a range of cells in the worksheet.
         
         Args:
             user_id: User ID for file organization
-            file_name: Name of the Excel file
+            filename: Name of the Excel file
             sheet_name: Name of worksheet
             range_address: Range to merge (e.g., 'A1:C3')
             
         Returns:
-            Success message with file_name
+            Success message with filename
         """
-        safe_file_name = get_safe_file_name(file_name)
-        file_path = mcp_server.file_manager.get_file_path(safe_file_name, user_id)
+        safe_filename = get_safe_filename(filename)
+        file_path = mcp_server.file_manager.get_file_path(safe_filename, user_id)
         try:
             with mcp_server.file_manager.lock_file(file_path):
                 result = merge_range(str(file_path), sheet_name, start_cell, end_cell)
-                safe_result = result["message"].replace(str(file_path), f"'{safe_file_name}'")
+                safe_result = result["message"].replace(str(file_path), f"'{safe_filename}'")
                 return safe_result
         except (ValidationError, SheetError) as e:
-            safe_error = str(e).replace(str(file_path), f"'{safe_file_name}'")
+            safe_error = str(e).replace(str(file_path), f"'{safe_filename}'")
             return f"Error: {safe_error}"
         except Exception as e:
             logger.error(f"Error merging cells: {e}")
             raise
         
     @mcp_server.tool(tags={"excel", "write"})
-    def unmerge_cells(user_id: str, file_name: str, sheet_name: str, start_cell: str, end_cell: str) -> str:
+    def unmerge_cells(user_id: str, filename: str, sheet_name: str, start_cell: str, end_cell: str) -> str:
         """
         Unmerge a range of cells in the worksheet.
         
         Args:
             user_id: User ID for file organization
-            file_name: Name of the Excel file
+            filename: Name of the Excel file
             sheet_name: Name of worksheet
             range_address: Range to unmerge (e.g., 'A1:C3')
             
         Returns:
-            Success message with file_name
+            Success message with filename
         """
-        safe_file_name = get_safe_file_name(file_name)
-        file_path = mcp_server.file_manager.get_file_path(safe_file_name, user_id)
+        safe_filename = get_safe_filename(filename)
+        file_path = mcp_server.file_manager.get_file_path(safe_filename, user_id)
         try:
             with mcp_server.file_manager.lock_file(file_path):
                 result = unmerge_range(str(file_path), sheet_name, start_cell, end_cell)
-                safe_result = result["message"].replace(str(file_path), f"'{safe_file_name}'")
+                safe_result = result["message"].replace(str(file_path), f"'{safe_filename}'")
                 return safe_result
         except (ValidationError, SheetError) as e:
-            safe_error = str(e).replace(str(file_path), f"'{safe_file_name}'")
+            safe_error = str(e).replace(str(file_path), f"'{safe_filename}'")
             return f"Error: {safe_error}"
         except Exception as e:
             logger.error(f"Error unmerging cells: {e}")
             raise
 
     @mcp_server.tool(tags={"excel", "write"})
-    def insert_rows(user_id: str, file_name: str, sheet_name: str, start_row: int, count: int = 1) -> str:
+    def insert_rows(user_id: str, filename: str, sheet_name: str, start_row: int, count: int = 1) -> str:
         """
         Insert one or more rows starting at the specified row.
         
         Args:
             user_id: User ID for file organization
-            file_name: Name of the Excel file
+            filename: Name of the Excel file
             sheet_name: Name of the worksheet
             start_row: Row number where insertion begins (1-based)
             count: Number of rows to insert (default: 1)
@@ -588,28 +588,28 @@ def register_excel_write_tools(mcp_server):
         Returns:
             Success message with operation details
         """
-        safe_file_name = get_safe_file_name(file_name)
-        file_path = mcp_server.file_manager.get_file_path(safe_file_name, user_id)
+        safe_filename = get_safe_filename(filename)
+        file_path = mcp_server.file_manager.get_file_path(safe_filename, user_id)
         try:
             with mcp_server.file_manager.lock_file(file_path):
                 result = insert_row(str(file_path), sheet_name, start_row, count)
-                safe_result = result["message"].replace(str(file_path), f"'{safe_file_name}'")
+                safe_result = result["message"].replace(str(file_path), f"'{safe_filename}'")
                 return safe_result
         except (ValidationError, SheetError) as e:
-            safe_error = str(e).replace(str(file_path), f"'{safe_file_name}'")
+            safe_error = str(e).replace(str(file_path), f"'{safe_filename}'")
             return f"Error: {safe_error}"
         except Exception as e:
             logger.error(f"Error inserting rows: {e}") 
             raise
 
     @mcp_server.tool(tags={"excel", "write"})
-    def insert_columns(user_id: str, file_name: str, sheet_name: str, start_col: int, count: int = 1) -> str:
+    def insert_columns(user_id: str, filename: str, sheet_name: str, start_col: int, count: int = 1) -> str:
         """
         Insert one or more columns starting at the specified column.
         
         Args:
             user_id: User ID for file organization
-            file_name: Name of the Excel file
+            filename: Name of the Excel file
             sheet_name: Name of the worksheet
             start_col: Column number where insertion begins (1-based)
             count: Number of columns to insert (default: 1)
@@ -617,28 +617,28 @@ def register_excel_write_tools(mcp_server):
         Returns:
             Success message with operation details
         """
-        safe_file_name = get_safe_file_name(file_name)
-        file_path = mcp_server.file_manager.get_file_path(safe_file_name, user_id)
+        safe_filename = get_safe_filename(filename)
+        file_path = mcp_server.file_manager.get_file_path(safe_filename, user_id)
         try:
             with mcp_server.file_manager.lock_file(file_path):
                 result = insert_cols(str(file_path), sheet_name, start_col, count)
-                safe_result = result["message"].replace(str(file_path), f"'{safe_file_name}'")
+                safe_result = result["message"].replace(str(file_path), f"'{safe_filename}'")
                 return safe_result
         except (ValidationError, SheetError) as e:
-            safe_error = str(e).replace(str(file_path), f"'{safe_file_name}'")
+            safe_error = str(e).replace(str(file_path), f"'{safe_filename}'")
             return f"Error: {safe_error}"
         except Exception as e:
             logger.error(f"Error inserting columns: {e}") 
             raise
 
     @mcp_server.tool(tags={"excel", "write"})
-    def delete_sheet_rows(user_id: str, file_name: str, sheet_name: str, start_row: int, count: int = 1) -> str:
+    def delete_sheet_rows(user_id: str, filename: str, sheet_name: str, start_row: int, count: int = 1) -> str:
         """
         Delete one or more rows starting at the specified row.
         
         Args:
             user_id: User ID for file organization
-            file_name: Name of the Excel file
+            filename: Name of the Excel file
             sheet_name: Name of the worksheet
             start_row: Row number where deletion begins (1-based)
             count: Number of rows to delete (default: 1)
@@ -646,28 +646,28 @@ def register_excel_write_tools(mcp_server):
         Returns:
             Success message with operation details
         """
-        safe_file_name = get_safe_file_name(file_name)
-        file_path = mcp_server.file_manager.get_file_path(safe_file_name, user_id)
+        safe_filename = get_safe_filename(filename)
+        file_path = mcp_server.file_manager.get_file_path(safe_filename, user_id)
         try:
             with mcp_server.file_manager.lock_file(file_path):
                 result = delete_rows(str(file_path), sheet_name, start_row, count)
-                safe_result = result["message"].replace(str(file_path), f"'{safe_file_name}'")
+                safe_result = result["message"].replace(str(file_path), f"'{safe_filename}'")
                 return safe_result
         except (ValidationError, SheetError) as e:
-            safe_error = str(e).replace(str(file_path), f"'{safe_file_name}'")
+            safe_error = str(e).replace(str(file_path), f"'{safe_filename}'")
             return f"Error: {safe_error}"
         except Exception as e:
             logger.error(f"Error deleting rows: {e}") 
             raise
         
     @mcp_server.tool(tags={"excel", "write"})
-    def delete_sheet_columns(user_id: str, file_name: str, sheet_name: str, start_col: int, count: int = 1) -> str:
+    def delete_sheet_columns(user_id: str, filename: str, sheet_name: str, start_col: int, count: int = 1) -> str:
         """
         Delete one or more columns starting at the specified column.
         
         Args:
             user_id: User ID for file organization
-            file_name: Name of the Excel file
+            filename: Name of the Excel file
             sheet_name: Name of the worksheet
             start_col: Column number where deletion begins (1-based)
             count: Number of columns to delete (default: 1)
@@ -675,15 +675,15 @@ def register_excel_write_tools(mcp_server):
         Returns:
             Success message with operation details
         """
-        safe_file_name = get_safe_file_name(file_name)
-        file_path = mcp_server.file_manager.get_file_path(safe_file_name, user_id)
+        safe_filename = get_safe_filename(filename)
+        file_path = mcp_server.file_manager.get_file_path(safe_filename, user_id)
         try:
             with mcp_server.file_manager.lock_file(file_path):
                 result = delete_cols(str(file_path), sheet_name, start_col, count)
-                safe_result = result["message"].replace(str(file_path), f"'{safe_file_name}'")
+                safe_result = result["message"].replace(str(file_path), f"'{safe_filename}'")
                 return safe_result
         except (ValidationError, SheetError) as e:
-            safe_error = str(e).replace(str(file_path), f"'{safe_file_name}'")
+            safe_error = str(e).replace(str(file_path), f"'{safe_filename}'")
             return f"Error: {safe_error}"
         except Exception as e:
             logger.error(f"Error deleting columns: {e}")
@@ -691,55 +691,55 @@ def register_excel_write_tools(mcp_server):
         
     # Workbook related tools
     @mcp_server.tool(tags={"excel", "write"})
-    def create_workbook(user_id: str, file_name: str) -> str:
+    def create_workbook(user_id: str, filename: str) -> str:
         """
         Create a new Excel workbook.
         
         Args:
             user_id: User ID for file organization
-            file_name: Name of the workbook file to create
+            filename: Name of the workbook file to create
         Returns:
-            Success message with the created file_name
+            Success message with the created filename
         """
-        safe_file_name = get_safe_file_name(file_name)
-        file_path = mcp_server.file_manager.get_file_path(safe_file_name, user_id)
+        safe_filename = get_safe_filename(filename)
+        file_path = mcp_server.file_manager.get_file_path(safe_filename, user_id)
         try:
             with mcp_server.file_manager.lock_file(file_path):
                 # Create new workbook
                 result = create_workbook_impl(str(file_path))
-                logger.info(f"Created workbook: {safe_file_name} for user {user_id}")
-                safe_result = result["message"].replace(str(file_path), f"'{safe_file_name}'")
+                logger.info(f"Created workbook: {safe_filename} for user {user_id}")
+                safe_result = result["message"].replace(str(file_path), f"'{safe_filename}'")
                 return safe_result
         except WorkbookError as e:
-            safe_error = str(e).replace(str(file_path), f"'{safe_file_name}'")
+            safe_error = str(e).replace(str(file_path), f"'{safe_filename}'")
             return f"Error: {safe_error}"
         except Exception as e:
             logger.error(f"Error creating workbook: {e}")
             raise
 
     @mcp_server.tool(tags={"excel", "write"})
-    def create_worksheet(user_id: str, file_name: str, sheet_name: str) -> str:
+    def create_worksheet(user_id: str, filename: str, sheet_name: str) -> str:
         """
         Create a new worksheet in an existing workbook.
         
         Args:
             user_id: User ID for file organization
-            file_name: Name of the workbook file
+            filename: Name of the workbook file
             sheet_name: Name for the new worksheet
             
         Returns:
             Success message with the created sheet name
         """
-        safe_file_name = get_safe_file_name(file_name)
-        file_path = mcp_server.file_manager.get_file_path(safe_file_name, user_id)
+        safe_filename = get_safe_filename(filename)
+        file_path = mcp_server.file_manager.get_file_path(safe_filename, user_id)
         try:
             with mcp_server.file_manager.lock_file(file_path):
                     result = create_sheet(str(file_path), sheet_name)
-                    logger.info(f"Created worksheet '{sheet_name}' in {safe_file_name} for user {user_id}")
+                    logger.info(f"Created worksheet '{sheet_name}' in {safe_filename} for user {user_id}")
                     safe_result = result["message"].replace(sheet_name, f"'{sheet_name}'")
                     return safe_result
         except (ValidationError, WorkbookError) as e:
-            safe_error = str(e).replace(str(file_path), f"'{safe_file_name}'")
+            safe_error = str(e).replace(str(file_path), f"'{safe_filename}'")
             return f"Error: {safe_error}"
         except Exception as e:
             logger.error(f"Error creating worksheet: {e}")

--- a/src/tools/minio_tools.py
+++ b/src/tools/minio_tools.py
@@ -7,7 +7,7 @@ import json
 from typing import List, Dict, Any
 from minio import Minio
 from minio.error import S3Error
-from ..core.file_manager import get_safe_file_name
+from ..core.file_manager import get_safe_filename
 from ..utils.exceptions import DataError
 from fastmcp.exceptions import ToolError
 
@@ -29,41 +29,41 @@ def _get_minio_client(config):
     )
 
 
-def _get_unique_file_name(client, bucket_name, user_id, base_file_name):
-    """Generate a unique file_name by checking existing files in MinIO."""
-    # First check if the base file_name exists
-    prefix = f"private/{user_id}/{base_file_name}"
+def _get_unique_filename(client, bucket_name, user_id, base_filename):
+    """Generate a unique filename by checking existing files in MinIO."""
+    # First check if the base filename exists
+    prefix = f"private/{user_id}/{base_filename}"
     objects = list(client.list_objects(bucket_name, prefix=prefix, recursive=False))
     
-    # If base file_name doesn't exist, return it as is
+    # If base filename doesn't exist, return it as is
     if not objects:
-        return base_file_name
+        return base_filename
     
-    # If base file_name exists, try numbered versions
-    file_stem = base_file_name
+    # If base filename exists, try numbered versions
+    file_stem = base_filename
     file_suffix = ""
     
     # Separate file extension if it exists
-    if "." in base_file_name:
-        file_parts = base_file_name.rsplit(".", 1)
+    if "." in base_filename:
+        file_parts = base_filename.rsplit(".", 1)
         file_stem = file_parts[0]
         file_suffix = f".{file_parts[1]}"
     
     # Try numbered versions starting from 1
     counter = 1
     while True:
-        new_file_name = f"{file_stem}({counter}){file_suffix}"
-        prefix = f"private/{user_id}/{new_file_name}"
+        new_filename = f"{file_stem}({counter}){file_suffix}"
+        prefix = f"private/{user_id}/{new_filename}"
         objects = list(client.list_objects(bucket_name, prefix=prefix, recursive=False))
     
-        # If this file_name doesn't exist, return it
+        # If this filename doesn't exist, return it
         if not objects:
-            return new_file_name
+            return new_filename
     
         counter += 1
         # Safety check to prevent infinite loops
         if counter > 1000:
-            raise ToolError("Unable to generate unique file_name after 1000 attempts.")
+            raise ToolError("Unable to generate unique filename after 1000 attempts.")
 
 
 def register_minio_tools(mcp_server):
@@ -79,7 +79,7 @@ def register_minio_tools(mcp_server):
             
         Returns:
             str: JSON string of file info objects. Each object contains:
-            - file_name (str)
+            - filename (str)
             - size (int)
             - last_modified (str | null)
         """
@@ -92,15 +92,15 @@ def register_minio_tools(mcp_server):
             file_list = []
             
             for obj in objects:
-                # Extract just the file_name from the object path
-                file_name = obj.object_name.split('/')[-1]
+                # Extract just the filename from the object path
+                filename = obj.object_name.split('/')[-1]
                 file_info = {
-                    "file_name": file_name,  # Return only file_name to avoid path confusion
+                    "filename": filename,  # Return only filename to avoid path confusion
                     "size": obj.size,
                     "last_modified": obj.last_modified.isoformat() if obj.last_modified else None
                 }
                 file_list.append(file_info)
-                logger.info(f"Found file: {file_name} for user {user_id}")
+                logger.info(f"Found file: {filename} for user {user_id}")
             return json.dumps(file_list, indent=2, default=str)
         except S3Error as e:
             logger.error(f"Error listing MinIO files: {e}")
@@ -110,25 +110,25 @@ def register_minio_tools(mcp_server):
             raise ToolError("An unexpected error occurred while listing files.")
 
     @mcp_server.tool(tags={"minio", "read"})
-    def pull_minio_file(user_id: str, file_name: str) -> str:
+    def pull_minio_file(user_id: str, filename: str) -> str:
         """
         Download a file from MinIO to the local Excel directory.
 
         Args:
             user_id (str): User ID for accessing user-specific files. This parameter is required.
-            file_name (str): Name of the file in MinIO. This parameter is required.
+            filename (str): Name of the file in MinIO. This parameter is required.
             
         Returns:
-            str: Success message with the file_name (not full path).
+            str: Success message with the filename (not full path).
         """
         try:
-            safe_file_name = get_safe_file_name(file_name)
+            safe_filename = get_safe_filename(filename)
             client = _get_minio_client(mcp_server.config)
             bucket_name = mcp_server.config.minio.bucket
             
             # Define the object path in MinIO and local file path
-            object_name = f"private/{user_id}/{safe_file_name}"
-            local_file_path = mcp_server.file_manager.get_file_path(safe_file_name, user_id)
+            object_name = f"private/{user_id}/{safe_filename}"
+            local_file_path = mcp_server.file_manager.get_file_path(safe_filename, user_id)
             
             # Create local directory if it doesn't exist
             local_file_path.parent.mkdir(parents=True, exist_ok=True)
@@ -136,9 +136,9 @@ def register_minio_tools(mcp_server):
             with mcp_server.file_manager.lock_file(local_file_path):
                 # Download the file from MinIO
                 client.fget_object(bucket_name, object_name, str(local_file_path))
-                logger.info(f"Successfully pulled file {safe_file_name} from MinIO for user {user_id}")
+                logger.info(f"Successfully pulled file {safe_filename} from MinIO for user {user_id}")
                 
-                return f"File '{safe_file_name}' downloaded successfully from MinIO"
+                return f"File '{safe_filename}' downloaded successfully from MinIO"
                 
         except S3Error as e:
             logger.error(f"Error pulling file from MinIO: {e}")
@@ -148,45 +148,45 @@ def register_minio_tools(mcp_server):
             raise ToolError("An unexpected error occurred while downloading the file.")
 
     @mcp_server.tool(tags={"minio", "write"})
-    def push_minio_file(user_id: str, file_name: str) -> str:
+    def push_minio_file(user_id: str, filename: str) -> str:
         """
         Upload a local Excel file to MinIO, then remove the local copy.
         The uploaded file gets a unique name to differentiate from originals.
 
         Args:
             user_id (str): User ID for accessing user-specific files. This parameter is required.
-            file_name (str): Name of the local file to upload. This parameter is required.
+            filename (str): Name of the local file to upload. This parameter is required.
             
         Returns:
-            str: Success message with the uploaded file_name.
+            str: Success message with the uploaded filename.
         """
         try:
-            safe_file_name = get_safe_file_name(file_name)
+            safe_filename = get_safe_filename(filename)
             client = _get_minio_client(mcp_server.config)
             bucket_name = mcp_server.config.minio.bucket
             
             # Define local file path
-            local_file_path = mcp_server.file_manager.get_file_path(safe_file_name, user_id)
+            local_file_path = mcp_server.file_manager.get_file_path(safe_filename, user_id)
             
             if not local_file_path.is_file():
-                raise FileNotFoundError(f"File not found: {safe_file_name}")
+                raise FileNotFoundError(f"File not found: {safe_filename}")
             
-            # Generate a unique file_name to avoid overwriting existing files
-            base_file_name = local_file_path.name
-            unique_file_name = _get_unique_file_name(client, bucket_name, user_id, base_file_name)
-            object_name = f"private/{user_id}/{unique_file_name}"
+            # Generate a unique filename to avoid overwriting existing files
+            base_filename = local_file_path.name
+            unique_filename = _get_unique_filename(client, bucket_name, user_id, base_filename)
+            object_name = f"private/{user_id}/{unique_filename}"
             
             with mcp_server.file_manager.lock_file(local_file_path):
                 try:
                     # Upload the file to MinIO
                     client.fput_object(bucket_name, object_name, str(local_file_path))
-                    logger.info(f"Successfully pushed file {safe_file_name} to MinIO as {unique_file_name}")
+                    logger.info(f"Successfully pushed file {safe_filename} to MinIO as {unique_filename}")
                     
                     # Remove the local file after successful upload
                     local_file_path.unlink()
-                    logger.info(f"Removed local file: {safe_file_name}")
+                    logger.info(f"Removed local file: {safe_filename}")
                     
-                    return f"File uploaded to MinIO as '{unique_file_name}', local copy {safe_file_name} has been removed"
+                    return f"File uploaded to MinIO as '{unique_filename}', local copy {safe_filename} has been removed"
                     
                 except S3Error as e:
                     logger.error(f"Error pushing file to MinIO: {e}")

--- a/src/utils/workbook.py
+++ b/src/utils/workbook.py
@@ -70,7 +70,7 @@ def get_workbook_info(filepath: str, include_ranges: bool = False) -> Dict[str, 
         wb = load_workbook(filepath, read_only=False)
         
         info = {
-            "file_name": path.name,
+            "filename": path.name,
             "sheets": wb.sheetnames,
             "size": path.stat().st_size,
             "modified": path.stat().st_mtime


### PR DESCRIPTION
## Summary
- standardize parameter name from `file_name` to `filename` across docs, utilities, and tools
- rename helper function to `get_safe_filename` and update references

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6899be62db58832f8fda1469561033fd